### PR TITLE
use Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - chmod +x gradlew deploy.sh
 
 script:
-  - ./gradlew build --stacktrace --no-daemon
+  - ./gradlew build --stacktrace
 
 after_success:
   - ./gradlew jacocoTestReport coveralls --stacktrace --no-daemon


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
